### PR TITLE
Confirmation page

### DIFF
--- a/src/routes/form-wizard/steps.js
+++ b/src/routes/form-wizard/steps.js
@@ -54,5 +54,7 @@ export default {
   '/check': {
     controller: MyController,
     next: 'confirmation'
+  },
+  '/confirmation': {
   }
 }

--- a/src/views/confirmation.html
+++ b/src/views/confirmation.html
@@ -1,0 +1,29 @@
+{% extends "layouts/main.html" %}
+
+{% from 'govuk/components/panel/macro.njk' import govukPanel %}
+
+{% set pageName = "Data sent" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    {{ govukPanel({
+      titleHtml: pageName
+    }) }}
+
+    <p>We’ve sent you a confirmation email.</p>
+
+    <h2 class="govuk-heading-m">What happens next</h2>
+
+    <p>We’ll send you an email once we publish the data. This usually happens within 5 working days.</p>
+
+    <h2 class="govuk-heading-m">
+      Give feedback
+    </h2>
+
+    <p><a href="#">Give feedback about this service</a> (takes 30 seconds).</p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/test/acceptance/upload_data.test.js
+++ b/test/acceptance/upload_data.test.js
@@ -82,4 +82,6 @@ test('Enter form information and upload a file with errors and without errors', 
   expect(await page.getByText('Bob Marley').isVisible(), 'supplied name not on check page').toBeTruthy()
   expect(await page.getByText('My Fake LPA').isVisible(), 'supplied email not on check page').toBeTruthy()
   await page.getByRole('button', { name: 'Send data' }).click()
+
+  await page.waitForURL('**/confirmation')
 })


### PR DESCRIPTION
Ticket: https://trello.com/c/6XKMHVYh/1098-add-confirmation-page

This ticket adds the confirmation page at the end of the form

![image](https://github.com/digital-land/lpa-data-validator-frontend/assets/15090285/424d4e3c-3793-4704-a74e-7bf1de041033)
