### PR TITLE
Show error descriptions instead of types

### DIFF
--- a/src/assets/scss/index.scss
+++ b/src/assets/scss/index.scss
@@ -8,6 +8,7 @@ $govuk-global-styles: true;
     border-left: 5px solid govuk-colour('red');
     padding: govuk-spacing(1) govuk-spacing(2);
     margin: 0;
+    width: 500px;
   
     .app-inset-text__value {
       margin-bottom: govuk-spacing(1);
@@ -16,6 +17,8 @@ $govuk-global-styles: true;
     .app-inset-text__error {
       color: govuk-colour('red');
       font-weight: bold;
+      white-space: normal;
+      min-width: fit-content;
     }
   
   

--- a/src/controllers/errorsController.js
+++ b/src/controllers/errorsController.js
@@ -44,7 +44,7 @@ class ErrorsController extends MyController {
           aggregatedIssues[entryNumber] = Object.keys(rowValues).reduce((acc, originalColumnName) => {
             const mappedColumnName = this.lookupMappedColumnNameFromOriginal(originalColumnName, apiResponseData['column-field-log'])
             acc[mappedColumnName] = {
-              error: false,
+              issue: false,
               value: rowValues[originalColumnName]
             }
             return acc

--- a/src/controllers/errorsController.js
+++ b/src/controllers/errorsController.js
@@ -55,7 +55,7 @@ class ErrorsController extends MyController {
           aggregatedIssues[entryNumber][issue.field] = {
             issue: {
               type: issue['issue-type'],
-              description: issue.description,
+              description: issue.description
             },
             value: rowValues[this.lookupOriginalColumnNameFromMapped(issue.field, apiResponseData['column-field-log'])]
           }

--- a/src/controllers/errorsController.js
+++ b/src/controllers/errorsController.js
@@ -53,7 +53,10 @@ class ErrorsController extends MyController {
 
         if (entryNumber in aggregatedIssues) {
           aggregatedIssues[entryNumber][issue.field] = {
-            error: this.lookupIssueType(issue['issue-type']),
+            issue: {
+              type: issue['issue-type'],
+              description: issue.description,
+            },
             value: rowValues[this.lookupOriginalColumnNameFromMapped(issue.field, apiResponseData['column-field-log'])]
           }
           issueCounts[issue.field] = issueCounts[issue.field] ? issueCounts[issue.field] + 1 : 1
@@ -62,11 +65,6 @@ class ErrorsController extends MyController {
     })
 
     return { aggregatedIssues, issueCounts }
-  }
-
-  lookupIssueType (issueType) {
-    // this needs to be implemented once we know what the issue types are
-    return issueType
   }
 
   lookupMappedColumnNameFromOriginal (originalColumnName, columnFieldLogs) {

--- a/src/views/errors.html
+++ b/src/views/errors.html
@@ -43,10 +43,10 @@
             <tr class="govuk-table__row">
               {% for columnName, column in row %}
               <td class="govuk-table__cell app-wrap">
-                  {% if column.error %}
+                  {% if column.issue %}
                     {{ govukInsetText({
                       classes: "app-inset-text---error",
-                      html: '<p class="app-inset-text__value">'+column.value+'</p> <p class="app-inset-text__error">'+column.error +'</p>'
+                      html: '<p class="app-inset-text__value">'+column.value+'</p> <p class="app-inset-text__error">'+column.issue.description +'</p>'
                     }) }}
                   {% else %}
                     {{column.value}}

--- a/test/testData/API_RUN_PIPELINE_RESPONSE.json
+++ b/test/testData/API_RUN_PIPELINE_RESPONSE.json
@@ -5,10 +5,10 @@
     {"Reference": "CA9", "Name": "Dartmouth Park", "Geometry": "POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))", "Start date": "01/06/1992", "Legislation": "", "Notes": "", "Point": "POINT (-0.145442349961 51.559999511433)", "End date": "", "Document URL": "https://www.camden.gov.uk/dartmouth-park-conservation-area-appraisal-and-management-strategy"}
   ],
   "issue-log": [
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "Start date", "issue-type": "invalid-value", "value": "40/04/1980", "severity": "error"},
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "geometry", "issue-type": "OSGB", "value": "", "severity": "info"},
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "organisation", "issue-type": "default-value", "value": "local-authority-eng:MAL", "severity": "info"},
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "entry-date", "issue-type": "default-value", "value": "2020-09-14", "severity": "info"}
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "Start date", "issue-type": "invalid-value", "description": "invalid-value", "value": "40/04/1980", "severity": "error"},
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "geometry", "issue-type": "OSGB", "description": "OSGB", "value": "", "severity": "info"},
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "organisation", "issue-type": "default-value", "description": "default-value", "value": "local-authority-eng:MAL", "severity": "info"},
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "entry-date", "issue-type": "default-value", "description": "default-value", "value": "2020-09-14", "severity": "info"}
   ],
   "flattened-csv": {
     "entities": [

--- a/test/unit/errorsController.test.js
+++ b/test/unit/errorsController.test.js
@@ -46,39 +46,42 @@ describe('ErrorsController', () => {
         rows: [
           {
             'Document URL': {
-              error: false,
+              issue: false,
               value: 'https://www.camden.gov.uk/camden-square-conservation-area-appraisal-and-management-strategy'
             },
             'End date': {
-              error: false,
+              issue: false,
               value: ''
             },
             Geometry: {
-              error: false,
+              issue: false,
               value: 'POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))'
             },
             Legislation: {
-              error: false,
+              issue: false,
               value: ''
             },
             Name: {
-              error: false,
+              issue: false,
               value: 'Camden Square'
             },
             Notes: {
-              error: false,
+              issue: false,
               value: ''
             },
             Point: {
-              error: false,
+              issue: false,
               value: 'POINT (-0.130484959448 51.544845663239)'
             },
             Reference: {
-              error: false,
+              issue: false,
               value: 'CA6'
             },
             'Start date': {
-              error: 'invalid-value',
+              issue: {
+                type: 'invalid-value',
+                description: 'invalid-value'
+              },
               value: '40/04/1980'
             }
           }

--- a/test/unit/errorsPage.test.js
+++ b/test/unit/errorsPage.test.js
@@ -22,51 +22,55 @@ describe('errors page', () => {
         rows: [
           {
             'Document URL': {
-              error: false,
               value: 'https://www.camden.gov.uk/holly-lodge-conservation-area'
             },
             'End date': {
-              error: false,
               value: ''
             },
             Geometry: {
-              error: 'fake error',
+              issue: {
+                type: 'fake error',
+                description: 'fake error'
+              },
               value: 'POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))'
             },
             Legislation: {
-              error: false,
               value: ''
             },
             Name: {
-              error: false,
               value: 'Holly Lodge Estate'
             },
             Notes: {
-              error: false,
               value: ''
             },
             Point: {
-              error: false,
               value: 'POINT (-0.150097204178 51.564975754948)'
             },
             Reference: {
-              error: false,
               value: 'CA20'
             },
             'Start date': {
-              error: false,
               value: '01/06/1992'
             },
             'entry-date': {
-              error: 'default-value',
+              issue: {
+                type: 'default-value',
+                description: 'default-value'
+              },
               value: undefined
             },
             geometry: {
-              error: 'OSGB',
+              issue: {
+                type: 'OSGB',
+                description: 'OSGB'
+              },
               value: undefined
             },
             organisation: {
-              error: 'default-value',
+              issue: {
+                type: 'default-value',
+                description: 'default-value'
+              },
               value: undefined
             }
           }


### PR DESCRIPTION
Ticket: https://trello.com/c/dYjAIi79/1120-mvp-make-the-issues-meaningful-on-the-error-page

this PR shows error descriptions instead of 

![image](https://github.com/digital-land/lpa-data-validator-frontend/assets/15090285/4714e527-4eee-491f-8730-e6e639c9b1c8)
