### PR TITLE
Group error messages

### DIFF
--- a/src/controllers/errorsController.js
+++ b/src/controllers/errorsController.js
@@ -59,7 +59,17 @@ class ErrorsController extends PageController {
             },
             value: rowValues[this.lookupOriginalColumnNameFromMapped(issue.field, apiResponseData['column-field-log'])]
           }
-          issueCounts[issue.field] = issueCounts[issue.field] ? issueCounts[issue.field] + 1 : 1
+          let key = issue.field + '_' + issue['issue-type']
+          if(issueCounts[key]){
+            issueCounts[key].count += 1;
+          }else{
+            issueCounts[key] = {
+              count: 1,
+              type: issue['issue-type'],
+              description: issue.description,
+              field: issue.field
+            }
+          }
         }
       }
     })

--- a/src/controllers/errorsController.js
+++ b/src/controllers/errorsController.js
@@ -59,10 +59,10 @@ class ErrorsController extends PageController {
             },
             value: rowValues[this.lookupOriginalColumnNameFromMapped(issue.field, apiResponseData['column-field-log'])]
           }
-          let key = issue.field + '_' + issue['issue-type']
-          if(issueCounts[key]){
-            issueCounts[key].count += 1;
-          }else{
+          const key = issue.field + '_' + issue['issue-type']
+          if (issueCounts[key]) {
+            issueCounts[key].count += 1
+          } else {
             issueCounts[key] = {
               count: 1,
               type: issue['issue-type'],

--- a/src/views/errors.html
+++ b/src/views/errors.html
@@ -17,8 +17,15 @@
       </h1>
 
       <ul class="govuk-list govuk-list--bullet">
-        {% for issue, count in options.issueCounts %}
-          <li>{{count}} issue, relating to {{issue}}</li>
+        {% for key, issue in options.issueCounts %}
+
+          {% if issue.count > 1 %}
+            {% set issueString = 'issues' %}
+          {% else %}
+            {% set issueString = 'issue' %}
+          {% endif %}
+
+          <li>{{issue.count}} {{issue.type}} {{issueString}}, relating to column {{issue.field}}</li>
         {% endfor %}
       </ul>
   </div>

--- a/test/unit/errorsController.test.js
+++ b/test/unit/errorsController.test.js
@@ -87,7 +87,12 @@ describe('ErrorsController', () => {
           }
         ],
         issueCounts: {
-          'Start date': 1
+          'Start date_invalid-value': {
+            count: 1,
+            description: 'invalid-value',
+            type: 'invalid-value',
+            field: 'Start date'
+          }
         }
       }
     }

--- a/test/unit/errorsPage.test.js
+++ b/test/unit/errorsPage.test.js
@@ -76,14 +76,18 @@ describe('errors page', () => {
           }
         ],
         issueCounts: {
-          geography: 1
+          'geography_fake error': {
+            count: 1,
+            type: 'fake error',
+            field: 'Geometry'
+          }
         },
         dataset: 'Dataset test'
       }
     }
     const html = nunjucks.render('errors.html', params).replace(/(\r\n|\n|\r)/gm, '').replace(/\t/gm, '').replace(/\s+/g, ' ')
 
-    expect(html).toContain('<li>1 issue, relating to geography</li>')
+    expect(html).toContain('<li>1 fake error issue, relating to column Geometry</li>')
     expect(html).toContain('<span class="govuk-caption-l"> Dataset test </span>')
     expect(html).toContain('<td class="govuk-table__cell app-wrap"> <div class="govuk-inset-text app-inset-text---error"> <p class="app-inset-text__value">POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))</p> <p class="app-inset-text__error">fake error</p></div> </td>')
   })


### PR DESCRIPTION
Ticket: https://trello.com/c/q9vRc045/1155-errors-need-grouping-by-error-and-not-just-column

this ticket ensure the errors in the error summary are grouped not only by field but also by issue-type

