### PR TITLE
hash the IP address and session id

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,20 +11,21 @@ import xGovFilters from '@x-govuk/govuk-prototype-filters'
 import formWizard from './src/routes/form-wizard/index.js'
 import validationMessageLookup from './src/filters/validationMessageLookup.js'
 import toErrorList from './src/filters/toErrorList.js'
+import hash from './src/utils/hasher.js'
 
 const { govukMarkdown } = xGovFilters
 
 const app = express()
 
-app.use((req, res, next) => {
+app.use(async (req, res, next) => {
   // log the request
   logger.info({
     type: 'Request',
     method: req.method,
     endpoint: req.originalUrl,
     message: `${req.method} request made to ${req.originalUrl}`,
-    sessionId: req.sessionID,
-    ipAddress: req.ip
+    sessionId: await hash(req.sessionID),
+    ipAddress: await hash(req.ip)
   })
   next()
 })

--- a/src/controllers/pageController.js
+++ b/src/controllers/pageController.js
@@ -1,5 +1,6 @@
 import hmpoFormWizard from 'hmpo-form-wizard'
 import logger from '../utils/logger.js'
+import hash from '../utils/hasher.js'
 const { Controller } = hmpoFormWizard
 
 class PageController extends Controller {
@@ -8,13 +9,13 @@ class PageController extends Controller {
     super.locals(req, res, callback)
   }
 
-  get (req, res, next) {
+  async get (req, res, next) {
     logger.info({
       type: 'PageView',
       pageRoute: this.options.route,
       message: `page view occurred for page: ${req.originalUrl}`,
-      sessionId: req.sessionID,
-      ipAddress: req.ip
+      sessionId: await hash(req.sessionID),
+      ipAddress: await hash(req.ip)
     })
     super.get(req, res, next)
   }

--- a/src/controllers/uploadController.js
+++ b/src/controllers/uploadController.js
@@ -8,6 +8,7 @@ import config from '../../config/index.js'
 
 import { severityLevels } from '../utils/utils.js'
 import logger from '../utils/logger.js'
+import hash from '../utils/hasher.js'
 
 const upload = multer({ dest: 'uploads/' })
 
@@ -30,8 +31,8 @@ class UploadController extends PageController {
           dataset: req.sessionModel.get('dataset'),
           dataSubject: req.sessionModel.get('data-subject'),
           organisation: 'local-authority-eng:CAT', // ToDo: this needs to be dynamic, not collected in the prototype, should it be?
-          sessionId: req.sessionID,
-          ipAddress: req.ip
+          sessionId: await hash(req.sessionID),
+          ipAddress: await hash(req.ip)
         })
         if (jsonResult) {
           try {

--- a/src/utils/hasher.js
+++ b/src/utils/hasher.js
@@ -1,0 +1,8 @@
+const { createHash } = require('crypto')
+
+export default (string) => {
+  if (!string) {
+    return ''
+  }
+  return createHash('sha256').update(string).digest('hex')
+}

--- a/src/utils/hasher.js
+++ b/src/utils/hasher.js
@@ -1,4 +1,4 @@
-const { createHash } = require('crypto')
+import { createHash } from 'crypto'
 
 export default (string) => {
   if (!string) {

--- a/test/mock-api/index.js
+++ b/test/mock-api/index.js
@@ -24,7 +24,7 @@ app.post(config.api.validationEndpoint, (req, res) => {
 
   if (filename !== 'conservation-area-errors.csv') {
     _toSend['issue-log'] = []
-    _toSend['missing-columns'] = []
+    _toSend['column-field-log'] = []
   }
   res.json(_toSend)
 })

--- a/test/unit/PageController.test.js
+++ b/test/unit/PageController.test.js
@@ -4,6 +4,8 @@ import { describe, it, vi, expect } from 'vitest'
 
 import logger from '../../src/utils/logger.js'
 
+import hash from '../../src/utils/hasher.js'
+
 describe('PageController', () => {
   const loggerInfoMock = vi.fn()
 
@@ -15,7 +17,7 @@ describe('PageController', () => {
 
   const loggerInfoSpy = vi.spyOn(logger, 'info')
 
-  it('Correctly creates a log when the page is viewed', () => {
+  it('Correctly creates a log when the page is viewed', async () => {
     const req = {
       originalUrl: '/dataset',
       sessionID: '123',
@@ -25,7 +27,7 @@ describe('PageController', () => {
       route: '/dataset'
     })
     // pageController.super.get = vi.fn();
-    pageController.get(req, {}, vi.fn())
+    await pageController.get(req, {}, vi.fn())
     expect(loggerInfoSpy).toHaveBeenCalledOnce()
 
     const callArgs = loggerInfoSpy.mock.calls[0][0]
@@ -33,8 +35,8 @@ describe('PageController', () => {
     expect(callArgs.type).toEqual('PageView')
     expect(callArgs.pageRoute).toEqual('/dataset')
     expect(callArgs.message).toEqual('page view occurred for page: /dataset')
-    expect(callArgs.sessionId).toEqual('123')
-    expect(callArgs.ipAddress).toEqual('1234')
+    expect(callArgs.sessionId).toEqual(await hash('123'))
+    expect(callArgs.ipAddress).toEqual(await hash('1234'))
     expect(callArgs.level).toEqual('info')
     expect(callArgs.service).toEqual('lpa-data-validation-frontend')
   })

--- a/test/unit/hasher.test.js
+++ b/test/unit/hasher.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import hash from '../../src/utils/hasher.js'
+
+describe('hasher', () => {
+  it('should return the same hash for the same string', async () => {
+    const string = 'test'
+    const hash1 = await hash(string)
+    const hash2 = await hash(string)
+    expect(hash1).toEqual(hash2)
+  })
+
+  it('should return the expected value for a given string', async () => {
+    const string = 'test'
+    const expectedValue = '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08'
+    const hash1 = await hash(string)
+    expect(hash1).toEqual(expectedValue)
+  })
+})


### PR DESCRIPTION
Ticket: https://trello.com/c/RxFpdnnx/1138-record-and-display-metrics-via-logs

This PR makes sure to log not the raw IP and session id, but instead a hash of these values

additional changes: 
- updated the mock api to remove the missing-fields field and instead return the column-field-log field