### PR TITLE
Quick fixes before prod

### DIFF
--- a/src/views/confirmation.html
+++ b/src/views/confirmation.html
@@ -20,7 +20,7 @@
 
   ## Licensing
 
-  The data is provided under the [Open Government Licence](#).
+  The data is provided under the [Open Government Licence](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
 
 {% endset %}
 

--- a/src/views/confirmation.html
+++ b/src/views/confirmation.html
@@ -49,7 +49,7 @@
 
   ## Give feedback
 
-  [Give feedback about this service](/feedback) (takes 30 seconds).
+  [Give feedback about this service]({{feedbackLink}}) (takes 30 seconds).
 
 {% endset %}
 

--- a/src/views/confirmation.html
+++ b/src/views/confirmation.html
@@ -4,7 +4,7 @@
 {% extends "layouts/main.html" %}
 
 
-{% set pageName = "Send your data for us to publish" %}
+{% set pageName = "Send us your data" %}
 
 {% block content %}
 

--- a/src/views/layouts/main.html
+++ b/src/views/layouts/main.html
@@ -56,11 +56,6 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
         Accessibility
       </a>
     </li>
-    <li class="govuk-footer__inline-list-item">
-      <a class="govuk-footer__link" href="/privacy-notice">
-        Privacy notice
-      </a>
-    </li>
   </ul>
   {% endset %}
 

--- a/src/views/start.html
+++ b/src/views/start.html
@@ -48,21 +48,7 @@
       {{content | govukMarkdown(headingsStartWith="l") | safe}}
     </div>
     <div class="govuk-grid-column-one-third">
-      {{ xGovukRelatedNavigation({
-        sections: [{
-          items: [{
-            text: "Data specification",
-            href: "/"
-          }],
-          subsections: [{
-            title: "Explore the topic",
-            items: [{
-              text: "Housing and planning",
-              href: "/browse/performing-arts"
-            }]
-          }]
-        }]
-      }) }}
+      
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
Ticket: https://trello.com/c/Smc4uN5i/1188-quick-changes-before-production

this ticket fixes the following

- remove content to the right on start page (related content and explore this topic)
- final green box should contain ‘send us your data’
- remove privacy notice link from footer
- [link ](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)to open gov license needs adding to confirm page
- feedback link on confirmation page not working