### PR TITLE
now render error summary from api

### DIFF
--- a/src/views/errors.html
+++ b/src/views/errors.html
@@ -17,18 +17,10 @@
       </h1>
 
       <ul class="govuk-list govuk-list--bullet">
-        {% for key, issue in options.issueCounts %}
-
-          {% if issue.count > 1 %}
-            {% set issueString = 'issues' %}
-          {% else %}
-            {% set issueString = 'issue' %}
-          {% endif %}
-
-          <li>{{issue.count}} {{issue.type}} {{issueString}}, relating to column {{issue.field}}</li>
-        {% endfor %}
-        {% for column in options.missingColumns %}
-          <li>Missing required column {{column}}</li>
+        {% for summaryMessage in options.errorSummary %}
+          <li>
+            {{summaryMessage}}
+          </li>
         {% endfor %}
       </ul>
   </div>

--- a/test/acceptance/missing_required_column.test.js
+++ b/test/acceptance/missing_required_column.test.js
@@ -23,5 +23,5 @@ test('when the user uploads a file with a missing required column, the page corr
 
   expect(await page.title()).toBe('Your data has errors - Publish planning and housing data for England')
 
-  expect(await page.textContent('.govuk-list')).toContain('Missing required column reference')
+  expect(await page.textContent('.govuk-list')).toContain('Reference column missing')
 })

--- a/test/testData/API_RUN_PIPELINE_RESPONSE.json
+++ b/test/testData/API_RUN_PIPELINE_RESPONSE.json
@@ -26,5 +26,11 @@
     {"entry-date": "2023-10-03T10:13:45Z", "dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "column": "Legislation", "field": "legislation"},
     {"entry-date": "2023-10-03T10:13:45Z", "dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "column": "Notes", "field": "notes"},
     {"field": "reference", "missing": true}
+  ],
+  "error-summary": [
+    "1 documentation URL must be a real URL",
+    "19 geometries must be in Well-Known Text (WKT) format",
+    "3 start dates must be a real date",
+    "Reference column missing"
   ]
 }

--- a/test/unit/errorsController.test.js
+++ b/test/unit/errorsController.test.js
@@ -81,17 +81,12 @@ describe('ErrorsController', () => {
             }
           }
         ],
-        missingColumns: [
-          'reference'
-        ],
-        issueCounts: {
-          'Start date_invalid-value': {
-            count: 1,
-            description: 'invalid-value',
-            type: 'invalid-value',
-            field: 'Start date'
-          }
-        }
+        errorSummary: [
+          '1 documentation URL must be a real URL',
+          '19 geometries must be in Well-Known Text (WKT) format',
+          '3 start dates must be a real date',
+          'Reference column missing'
+        ]
       }
     }
 
@@ -139,23 +134,10 @@ describe('ErrorsController', () => {
           }
         }
       }
-      const expectedIssueCounts = {
-        'Start date_invalid-value': {
-          count: 1,
-          description: 'invalid-value',
-          type: 'invalid-value',
-          field: 'Start date'
-        }
-      }
-      const expectedMissingColumns = [
-        'reference'
-      ]
 
-      const { aggregatedIssues, issueCounts, missingColumns } = errorsController.getAggregatedErrors(mockApiValue)
+      const { aggregatedIssues } = errorsController.getAggregatedErrors(mockApiValue)
 
       expect(aggregatedIssues).toEqual(expectedAggregatedIssues)
-      expect(issueCounts).toEqual(expectedIssueCounts)
-      expect(missingColumns).toEqual(expectedMissingColumns)
     })
   })
 })

--- a/test/unit/errorsPage.test.js
+++ b/test/unit/errorsPage.test.js
@@ -75,19 +75,17 @@ describe('errors page', () => {
             }
           }
         ],
-        issueCounts: {
-          'geography_fake error': {
-            count: 1,
-            type: 'fake error',
-            field: 'Geometry'
-          }
-        },
+        errorSummary: [
+          '1 documentation URL must be a real URL',
+          '19 geometries must be in Well-Known Text (WKT) format'
+        ],
         dataset: 'Dataset test'
       }
     }
     const html = nunjucks.render('errors.html', params).replace(/(\r\n|\n|\r)/gm, '').replace(/\t/gm, '').replace(/\s+/g, ' ')
 
-    expect(html).toContain('<li>1 fake error issue, relating to column Geometry</li>')
+    expect(html).toContain('<li> 1 documentation URL must be a real URL </li>')
+    expect(html).toContain('<li> 19 geometries must be in Well-Known Text (WKT) format </li>')
     expect(html).toContain('<span class="govuk-caption-l"> Dataset test </span>')
     expect(html).toContain('<td class="govuk-table__cell app-wrap"> <div class="govuk-inset-text app-inset-text---error"> <p class="app-inset-text__value">POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))</p> <p class="app-inset-text__error">fake error</p></div> </td>')
   })


### PR DESCRIPTION
Ticket: https://trello.com/c/5Lx4U7uL/1189-improve-error-summary-messages

This PR changes the error summary to render messages received from the backend 

![image](https://github.com/digital-land/lpa-data-validator-frontend/assets/15090285/6f751009-d328-46a8-98d5-23c7bee120ec)
