### PR TITLE
Pretty column name lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,14 +7,10 @@ import session from 'express-session'
 import nunjucks from 'nunjucks'
 import bodyParser from 'body-parser'
 import config from './config/index.js'
-import xGovFilters from '@x-govuk/govuk-prototype-filters'
 import formWizard from './src/routes/form-wizard/index.js'
-import validationMessageLookup from './src/filters/validationMessageLookup.js'
-import toErrorList from './src/filters/toErrorList.js'
 import hash from './src/utils/hasher.js'
 import accessibility from './src/routes/accessibility.js'
-
-const { govukMarkdown } = xGovFilters
+import addFilters from './src/filters/filters.js'
 
 const app = express()
 
@@ -65,9 +61,7 @@ const globalValues = {
 Object.keys(globalValues).forEach((key) => {
   nunjucksEnv.addGlobal(key, globalValues[key])
 })
-nunjucksEnv.addFilter('govukMarkdown', govukMarkdown)
-nunjucksEnv.addFilter('validationMessageLookup', validationMessageLookup)
-nunjucksEnv.addFilter('toErrorList', toErrorList)
+addFilters(nunjucksEnv)
 
 // body parser
 app.use(bodyParser.urlencoded({ extended: true }))

--- a/src/controllers/errorsController.js
+++ b/src/controllers/errorsController.js
@@ -68,7 +68,7 @@ class ErrorsController extends PageController {
           aggregatedIssues[entryNumber][issue.field] = {
             issue: {
               type: issue['issue-type'],
-              description: issue.description
+              description: issue.message
             },
             value: rowValues[columnName]
           }

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -1,0 +1,15 @@
+import xGovFilters from '@x-govuk/govuk-prototype-filters'
+import validationMessageLookup from './validationMessageLookup.js'
+import toErrorList from './toErrorList.js'
+import prettifyColumnName from './prettifyColumnName.js'
+
+const { govukMarkdown } = xGovFilters
+
+const addFilters = (nunjucksEnv) => {
+    nunjucksEnv.addFilter('govukMarkdown', govukMarkdown)
+    nunjucksEnv.addFilter('validationMessageLookup', validationMessageLookup)
+    nunjucksEnv.addFilter('toErrorList', toErrorList)
+    nunjucksEnv.addFilter('prettifyColumnName', prettifyColumnName)
+}
+
+export default addFilters

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -6,10 +6,10 @@ import prettifyColumnName from './prettifyColumnName.js'
 const { govukMarkdown } = xGovFilters
 
 const addFilters = (nunjucksEnv) => {
-    nunjucksEnv.addFilter('govukMarkdown', govukMarkdown)
-    nunjucksEnv.addFilter('validationMessageLookup', validationMessageLookup)
-    nunjucksEnv.addFilter('toErrorList', toErrorList)
-    nunjucksEnv.addFilter('prettifyColumnName', prettifyColumnName)
+  nunjucksEnv.addFilter('govukMarkdown', govukMarkdown)
+  nunjucksEnv.addFilter('validationMessageLookup', validationMessageLookup)
+  nunjucksEnv.addFilter('toErrorList', toErrorList)
+  nunjucksEnv.addFilter('prettifyColumnName', prettifyColumnName)
 }
 
 export default addFilters

--- a/src/filters/prettifyColumnName.js
+++ b/src/filters/prettifyColumnName.js
@@ -1,0 +1,20 @@
+const prettifyColumnName = (columnName) => {
+    // Split the string on underscores and spaces
+    let words = columnName.split(/[-\s]/);
+  
+    // Capitalize the first letter of the first word and make 'url' uppercase
+    let title = words.map((word, index) => {
+        console.log(`word: ${word}, word.toLowerCase(): ${word.toLowerCase()}`); 
+        if (word.toLowerCase() === 'url') {
+            return word.toUpperCase();
+        } else if (index === 0) {
+            return word.charAt(0).toUpperCase() + word.slice(1);
+        } else {
+            return word;
+        }
+    }).join(' ');
+  
+    return title;
+}
+
+export default prettifyColumnName

--- a/src/filters/prettifyColumnName.js
+++ b/src/filters/prettifyColumnName.js
@@ -1,20 +1,20 @@
 const prettifyColumnName = (columnName) => {
-    // Split the string on underscores and spaces
-    let words = columnName.split(/[-\s]/);
-  
-    // Capitalize the first letter of the first word and make 'url' uppercase
-    let title = words.map((word, index) => {
-        console.log(`word: ${word}, word.toLowerCase(): ${word.toLowerCase()}`); 
-        if (word.toLowerCase() === 'url') {
-            return word.toUpperCase();
-        } else if (index === 0) {
-            return word.charAt(0).toUpperCase() + word.slice(1);
-        } else {
-            return word;
-        }
-    }).join(' ');
-  
-    return title;
+  // Split the string on underscores and spaces
+  const words = columnName.split(/[-\s]/)
+
+  // Capitalize the first letter of the first word and make 'url' uppercase
+  const title = words.map((word, index) => {
+    console.log(`word: ${word}, word.toLowerCase(): ${word.toLowerCase()}`)
+    if (word.toLowerCase() === 'url') {
+      return word.toUpperCase()
+    } else if (index === 0) {
+      return word.charAt(0).toUpperCase() + word.slice(1)
+    } else {
+      return word
+    }
+  }).join(' ')
+
+  return title
 }
 
 export default prettifyColumnName

--- a/src/filters/prettifyColumnName.js
+++ b/src/filters/prettifyColumnName.js
@@ -4,7 +4,6 @@ const prettifyColumnName = (columnName) => {
 
   // Capitalize the first letter of the first word and make 'url' uppercase
   const title = words.map((word, index) => {
-    console.log(`word: ${word}, word.toLowerCase(): ${word.toLowerCase()}`)
     if (word.toLowerCase() === 'url') {
       return word.toUpperCase()
     } else if (index === 0) {

--- a/src/views/errors.html
+++ b/src/views/errors.html
@@ -49,7 +49,7 @@
                     {% if column.issue %}
                       {{ govukInsetText({
                         classes: "app-inset-text---error",
-                        html: '<p class="app-inset-text__value">'+column.value | striptags +'</p> <p class="app-inset-text__error">'+column.issue.description +'</p>'
+                        html: '<p class="app-inset-text__value">'+column.value | striptags +'</p> <p class="app-inset-text__error">'+column.issue.description | prettifyColumnName +'</p>'
                       }) }}
                     {% else %}
                       {{column.value}}

--- a/test/testData/API_RUN_PIPELINE_RESPONSE.json
+++ b/test/testData/API_RUN_PIPELINE_RESPONSE.json
@@ -5,10 +5,10 @@
     {"Name": "Dartmouth Park", "Geometry": "POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))", "Start date": "01/06/1992", "Legislation": "", "Notes": "", "Point": "POINT (-0.145442349961 51.559999511433)", "End date": "", "Document URL": "https://www.camden.gov.uk/dartmouth-park-conservation-area-appraisal-and-management-strategy"}
   ],
   "issue-log": [
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "start-date", "issue-type": "invalid-value", "description": "invalid-value", "value": "40/04/1980", "severity": "error"},
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "geometry", "issue-type": "OSGB", "description": "OSGB", "value": "", "severity": "info"},
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "organisation", "issue-type": "default-value", "description": "default-value", "value": "local-authority-eng:MAL", "severity": "info"},
-    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "entry-date", "issue-type": "default-value", "description": "default-value", "value": "2020-09-14", "severity": "info"}
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "start-date", "issue-type": "invalid-value", "message": "invalid-value", "value": "40/04/1980", "severity": "error"},
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "geometry", "issue-type": "OSGB", "message": "OSGB", "value": "", "severity": "info"},
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "organisation", "issue-type": "default-value", "message": "default-value", "value": "local-authority-eng:MAL", "severity": "info"},
+    {"dataset": "conservation-area", "resource": "0b4284077da580a6daea59ee2227f9c7c55a9a45d57ef470d82418a4391ddf9a", "line-number": "2", "entry-number": "1", "field": "entry-date", "issue-type": "default-value", "message": "default-value", "value": "2020-09-14", "severity": "info"}
   ],
   "flattened-csv": {
     "entities": [

--- a/test/unit/errorsPage.test.js
+++ b/test/unit/errorsPage.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 
 import nunjucks from 'nunjucks'
-const { govukMarkdown } = require('@x-govuk/govuk-prototype-filters')
+import addFilters from '../../src/filters/filters'
 
 const nunjucksEnv = nunjucks.configure([
   'src/views',
@@ -13,7 +13,7 @@ const nunjucksEnv = nunjucks.configure([
   watch: true
 })
 
-nunjucksEnv.addFilter('govukMarkdown', govukMarkdown)
+addFilters(nunjucksEnv)
 
 describe('errors page', () => {
   it('renders the correct number of errors', () => {
@@ -87,6 +87,6 @@ describe('errors page', () => {
     expect(html).toContain('<li> 1 documentation URL must be a real URL </li>')
     expect(html).toContain('<li> 19 geometries must be in Well-Known Text (WKT) format </li>')
     expect(html).toContain('<span class="govuk-caption-l"> Dataset test </span>')
-    expect(html).toContain('<td class="govuk-table__cell app-wrap"> <div class="govuk-inset-text app-inset-text---error"> <p class="app-inset-text__value">POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))</p> <p class="app-inset-text__error">fake error</p></div> </td>')
+    expect(html).toContain('<td class="govuk-table__cell app-wrap"> <div class="govuk-inset-text app-inset-text---error"> <p class="app-inset-text__value">POLYGON ((-0.125888391245 51.54316508186, -0.125891457623 51.543177267548, -0.125903428774 51.54322160042))</p> <p class="app-inset-text__error">Fake error</p></div> </td>')
   })
 })

--- a/test/unit/prettifyColumnName.test.js
+++ b/test/unit/prettifyColumnName.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import prettifyColumnName from '../../src/filters/prettifyColumnName'
+
+describe('prettifyColumnName', () => {
+  it('should capitalize the first letter of the first word', () => {
+    expect(prettifyColumnName('start-date')).toBe('Start date')
+  })
+
+  it('should make "url" uppercase', () => {
+    expect(prettifyColumnName('document-url')).toBe('Document URL')
+  })
+
+  it('should handle strings with no underscores or spaces', () => {
+    expect(prettifyColumnName('geography')).toBe('Geography')
+  })
+
+  it('should handle strings with spaces', () => {
+    expect(prettifyColumnName('start date')).toBe('Start date')
+  })
+
+  it('should handle strings with mixed underscores and spaces', () => {
+    expect(prettifyColumnName('document-url start date-is today')).toBe('Document URL start date is today')
+  })
+})


### PR DESCRIPTION
Ticket: https://trello.com/c/RNhBP4Lx/1178-introduce-a-new-column-in-issue-log-to-handle-customized-messages?filter=member:georgegoodall8

this ticket adds a filter for formatting column names displayed in error messages in a prettier way

some examples

document-url  -> Document URL
start-date        -> Start date
geography      -> Geography