### PR TITLE
Allow secure cookies via proxy

### DIFF
--- a/src/serverSetup/session.js
+++ b/src/serverSetup/session.js
@@ -19,7 +19,10 @@ export function setupSession (app) {
       client: redisClient
     })
   }
-
+  // Trust first proxy otherwise secure cookies will not be returned
+  // See https://github.com/expressjs/session?tab=readme-ov-file#cookiesecure
+  // See https://expressjs.com/en/guide/behind-proxies.html
+  app.set('trust proxy', 1) // trust first proxy
   app.use(session({
     secret: process.env.SESSION_SECRET || 'keyboard cat',
     resave: false,


### PR DESCRIPTION
Set trust proxy setting so that secure cookies are sent via proxy, e.g. load balancer, cloudfront