### PR TITLE
NOTICKET: minor tweaks

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,4 +1,4 @@
-port: 5000
+port: 8001
 asyncRequestApi: {
     url: https://publish-api.planning.data.gov.uk,
     port: 8082,

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,4 +1,4 @@
-port: 8001
+port: 8011
 asyncRequestApi: {
     url: https://publish-api.planning.data.gov.uk,
     port: 8082,

--- a/src/routes/health.js
+++ b/src/routes/health.js
@@ -2,6 +2,7 @@ import express from 'express'
 import config from '../../config/index.js'
 import AWS from 'aws-sdk'
 import { createClient } from 'redis'
+import logger from '../utils/logger.js'
 
 const router = express.Router()
 
@@ -71,7 +72,10 @@ const checkRedis = async () => {
       return false
     }
   }).catch((err) => {
-    console.log('error:', err)
+    logger.error(`checkRedis/connect: ${err.message}`)
+    if (config.environment !== 'test') {
+      console.error(err)
+    }
     return false
   })
 }

--- a/src/serverSetup/middlewares.js
+++ b/src/serverSetup/middlewares.js
@@ -6,13 +6,13 @@ import hash from '../utils/hasher.js'
 import config from '../../config/index.js'
 
 export function setupMiddlewares (app) {
-  app.use(async (req, res, next) => {
+  app.use((req, res, next) => {
     logger.info({
       type: 'Request',
       method: req.method,
       endpoint: req.originalUrl,
       message: `${req.method} request made to ${req.originalUrl}`,
-      sessionId: await hash(req.sessionID)
+      sessionId: hash(req.sessionID)
     })
     next()
   })

--- a/src/serverSetup/session.js
+++ b/src/serverSetup/session.js
@@ -13,7 +13,10 @@ export function setupSession (app) {
     const redisClient = createClient({
       url: `${urlPrefix}://${config.redis.host}:${config.redis.port}`
     })
-    redisClient.connect().catch(logger.error)
+    const errorHandler = (err) => {
+      logger.error(`redis connection error ${err.code}`)
+    }
+    redisClient.connect().catch(errorHandler)
 
     sessionStore = new RedisStore({
       client: redisClient

--- a/src/serverSetup/session.js
+++ b/src/serverSetup/session.js
@@ -14,7 +14,7 @@ export function setupSession (app) {
       url: `${urlPrefix}://${config.redis.host}:${config.redis.port}`
     })
     const errorHandler = (err) => {
-      logger.error(`redis connection error ${err.code}`)
+      logger.error(`session/setupSession: redis connection error: ${err.code}`)
     }
     redisClient.connect().catch(errorHandler)
 

--- a/src/utils/fetchLocalAuthorities.js
+++ b/src/utils/fetchLocalAuthorities.js
@@ -1,4 +1,6 @@
 import axios from 'axios'
+import logger from './logger'
+import config from '../../config'
 
 /**
  * Fetches a list of local authority names from a specified dataset.
@@ -36,7 +38,10 @@ export const fetchLocalAuthorities = async () => {
     }).filter(name => name !== null) // Filter out null values
     return names // Return the fetched data
   } catch (error) {
-    console.error('Error fetching local authorities data:', error)
+    logger.error(`fetchLocalAuthorities: Error fetching local authorities data: ${error.message}`)
+    if (config.environment !== 'test') {
+      console.error(error)
+    }
     throw error // Rethrow the error to be handled by the caller
   }
 }

--- a/src/utils/fetchLocalAuthorities.js
+++ b/src/utils/fetchLocalAuthorities.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
-import logger from './logger'
-import config from '../../config'
+import logger from '../../src/utils/logger.js'
+import config from '../../config/index.js'
 
 /**
  * Fetches a list of local authority names from a specified dataset.
@@ -36,12 +36,12 @@ export const fetchLocalAuthorities = async () => {
         return row[1]
       }
     }).filter(name => name !== null) // Filter out null values
-    return names // Return the fetched data
+    return names
   } catch (error) {
     logger.error(`fetchLocalAuthorities: Error fetching local authorities data: ${error.message}`)
     if (config.environment !== 'test') {
       console.error(error)
     }
-    throw error // Rethrow the error to be handled by the caller
+    throw error
   }
 }

--- a/test/unit/health.test.js
+++ b/test/unit/health.test.js
@@ -52,7 +52,7 @@ describe('Health checks', () => {
 
   test('checkRedis returns false when Redis is not reachable', async () => {
     const mockClient = {
-      connect: vi.fn().mockRejectedValue(new Error()),
+      connect: vi.fn().mockRejectedValue(new Error('redis not reachable!')),
       isOpen: false,
       quit: vi.fn()
     }


### PR DESCRIPTION
Various unrelated changes: 
- change default PORT to 8011 (5000 conflicts with a macOS service)
- better logging on Redis connection error
- remove unnecessary async/await
- less noisy test output (omit logging stack traces in few places in 'test' environment)