### PR TITLE
Add Smartlook integration

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,7 +1,6 @@
 import HmpoConfig from 'hmpo-config'
 import yaml from 'js-yaml'
 import fs from 'fs'
-import _ from 'lodash'
 
 const readConfig = (config) => {
   return yaml.load(fs.readFileSync(`./config/${config}.yaml`, 'utf8'))
@@ -16,7 +15,7 @@ const getConfig = () => {
 
   const customConfig = readConfig(environment)
 
-  const combinedConfig = _.merge({}, defaultConfig, customConfig)
+  const combinedConfig = Object.assign({}, defaultConfig, customConfig)
 
   const config = new HmpoConfig()
   config.addConfig(combinedConfig)

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -11,3 +11,7 @@ redis: {
     port: '6379'
 }
 url: 'https://publish.digital-land.info/'
+smartlook: {
+  key: '6383ab27d6f6a02f043a518bea629cd232dc0131',
+  region: 'eu'
+}

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,6 +1,7 @@
 asyncRequestApi: {
     url: http://localhost:8001,
-    port: 8001
+    port: 8001,
+    requestsEndpoint: 'requests'
 }
 aws: {
     region: eu-west-2,

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:acceptance": "NODE_ENV=development playwright test --config ./test/acceptance/playwright.config.js",
     "test:acceptance:ci": "NODE_ENV=ci playwright test --config ./test/acceptance/playwright.config.js",
     "playwright-codegen": "playwright codegen http://localhost:5000",
-    "lint": "standard",
-    "lint:fix": "standard --fix"
+    "lint": "standard --ignore=src/views/common/smartlook.js",
+    "lint:fix": "standard --fix --ignore=src/views/common/smartlook.js"
   },
   "engines": {
     "node": ">=18.0.0 <20.0.0"
@@ -73,7 +73,6 @@
     "hmpo-form-wizard": "^13.0.0",
     "hmpo-i18n": "^6.0.1",
     "js-yaml": "^4.1.0",
-    "lodash": "^4.17.21",
     "maplibre-gl": "^4.1.0",
     "multer": "^1.4.5-lts.1",
     "notifications-node-client": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test:acceptance": "NODE_ENV=development playwright test --config ./test/acceptance/playwright.config.js",
     "test:acceptance:ci": "NODE_ENV=ci playwright test --config ./test/acceptance/playwright.config.js",
     "playwright-codegen": "playwright codegen http://localhost:5000",
-    "lint": "standard --ignore=src/views/common/smartlook.js",
-    "lint:fix": "standard --fix --ignore=src/views/common/smartlook.js"
+    "lint": "standard",
+    "lint:fix": "standard --fix"
   },
   "engines": {
     "node": ">=18.0.0 <20.0.0"
@@ -93,7 +93,8 @@
   },
   "standard": {
     "ignore": [
-      "performance-test/"
+      "performance-test/",
+      "src/views/common/smartlook.js"
     ]
   }
 }

--- a/src/serverSetup/nunjucks.js
+++ b/src/serverSetup/nunjucks.js
@@ -25,6 +25,11 @@ export function setupNunjucks ({ app, dataSubjects }) {
     feedbackLink: config.feedbackLink
   }
 
+  if ('smartlook' in config) {
+    globalValues.smartlookKey = config.smartlook.key
+    globalValues.smartlookRegion = config.smartlook.region
+  }
+
   Object.keys(globalValues).forEach((key) => {
     nunjucksEnv.addGlobal(key, globalValues[key])
   })

--- a/src/views/common/smartlook.js
+++ b/src/views/common/smartlook.js
@@ -1,0 +1,6 @@
+window.smartlook || (function (d) {
+  var o = smartlook = function () { o.api.push(arguments) }; const h = d.getElementsByTagName('head')[0]
+  const c = d.createElement('script'); o.api = new Array(); c.async = true; c.type = 'text/javascript'
+  c.charset = 'utf-8'; c.src = 'https://web-sdk.smartlook.com/recorder.js'; h.appendChild(c)
+})(document)
+smartlook('init', '{{ smartlookKey }}', { region: '{{ smartlookRegion }}' })

--- a/src/views/layouts/main.html
+++ b/src/views/layouts/main.html
@@ -19,6 +19,13 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 
 {% block head %}
   <link rel="stylesheet" href="/public/stylesheets/index.css">
+  {% if smartlookKey %}
+    {% block smartlook %}
+      <script type='text/javascript'>
+      {% include "common/smartlook.js" %}
+      </script>
+    {% endblock %}
+  {% endif %}
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
Adds integration with Smartlook to enable recording (anonymised) website usage data.

This is a barebones integration - no custom events at the moment. It will be included in the served HTML only when the server has appropriate environment variables set (see config/production.yaml).
