### PR TITLE
Fix/xgov stack overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sentry/node": "^8.7.0",
         "@sentry/profiling-node": "^8.7.0",
         "@x-govuk/govuk-prototype-components": "^3.0.5",
-        "@x-govuk/govuk-prototype-filters": "^1.4.0",
+        "@x-govuk/govuk-prototype-filters": "^1.4.1",
         "accessible-autocomplete": "^3.0.0",
         "aws-sdk": "^2.1581.0",
         "axios": "^1.6.2",
@@ -3219,13 +3219,14 @@
       }
     },
     "node_modules/@x-govuk/govuk-prototype-filters": {
-      "version": "1.4.0",
-      "license": "MIT",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-filters/-/govuk-prototype-filters-1.4.1.tgz",
+      "integrity": "sha512-ykybsndEUMEZuBWb1da0J6NkTXjf2Trn1TlZYaFGNF8aFiYWV3yiHIByyBgdJ4xY9rsIWyDdkZaW+uTi0hxR4A==",
       "dependencies": {
         "govuk-markdown": "^0.7.0",
         "lodash": "^4.17.21",
         "luxon": "^3.2.1",
-        "marked": "^12.0.0",
+        "marked": "^13.0.0",
         "marked-smartypants": "^1.0.0",
         "pluralize": "^8.0.0"
       },
@@ -8992,8 +8993,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "12.0.2",
-      "license": "MIT",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.2.tgz",
+      "integrity": "sha512-J6CPjP8pS5sgrRqxVRvkCIkZ6MFdRIjDkwUwgJ9nL2fbmM6qGQeB2C16hi8Cc9BOzj6xXzy0jyi0iPIfnMHYzA==",
       "bin": {
         "marked": "bin/marked.js"
       },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@sentry/node": "^8.7.0",
     "@sentry/profiling-node": "^8.7.0",
     "@x-govuk/govuk-prototype-components": "^3.0.5",
-    "@x-govuk/govuk-prototype-filters": "^1.4.0",
+    "@x-govuk/govuk-prototype-filters": "^1.4.1",
     "accessible-autocomplete": "^3.0.0",
     "aws-sdk": "^2.1581.0",
     "axios": "^1.6.2",

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -1,11 +1,36 @@
 import { getkeys, getContext } from './debuggingFilters.js'
-import xGovFilters from '@x-govuk/govuk-prototype-filters'
 import validationMessageLookup from './validationMessageLookup.js'
 import toErrorList from './toErrorList.js'
 import prettifyColumnName from './prettifyColumnName.js'
 import getFullServiceName from './getFullServiceName.js'
 
-const { govukMarkdown } = xGovFilters
+// import xGovFilters from '@x-govuk/govuk-prototype-filters'
+// const { govukMarkdown } = xGovFilters
+
+// govuk markdown has a bug in it, until that is resolved we will build the filter here instead
+
+import markedGovukMarkdown from 'govuk-markdown'
+import { markedSmartypants } from 'marked-smartypants'
+import { normalize } from '@x-govuk/govuk-prototype-filters/lib/utils.js'
+import { marked } from 'marked'
+
+const govukMarkdown = (string, kwargs) => {
+  string = normalize(string, '')
+
+  marked.default = {}
+
+  marked.use(
+    markedGovukMarkdown({
+      headingsStartWith: 'm',
+    })
+  )
+  
+  marked.use(markedSmartypants())
+
+  return marked(string)
+}
+
+
 
 /**
  *

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -7,7 +7,6 @@ import getFullServiceName from './getFullServiceName.js'
 
 const { govukMarkdown } = xGovFilters
 
-
 /**
  *
  * @param {*} dataSubjects

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -21,16 +21,14 @@ const govukMarkdown = (string, kwargs) => {
 
   marked.use(
     markedGovukMarkdown({
-      headingsStartWith: 'm',
+      headingsStartWith: 'm'
     })
   )
-  
+
   marked.use(markedSmartypants())
 
   return marked(string)
 }
-
-
 
 /**
  *

--- a/src/filters/filters.js
+++ b/src/filters/filters.js
@@ -1,34 +1,12 @@
 import { getkeys, getContext } from './debuggingFilters.js'
+import xGovFilters from '@x-govuk/govuk-prototype-filters'
 import validationMessageLookup from './validationMessageLookup.js'
 import toErrorList from './toErrorList.js'
 import prettifyColumnName from './prettifyColumnName.js'
 import getFullServiceName from './getFullServiceName.js'
 
-// import xGovFilters from '@x-govuk/govuk-prototype-filters'
-// const { govukMarkdown } = xGovFilters
+const { govukMarkdown } = xGovFilters
 
-// govuk markdown has a bug in it, until that is resolved we will build the filter here instead
-
-import markedGovukMarkdown from 'govuk-markdown'
-import { markedSmartypants } from 'marked-smartypants'
-import { normalize } from '@x-govuk/govuk-prototype-filters/lib/utils.js'
-import { marked } from 'marked'
-
-const govukMarkdown = (string, kwargs) => {
-  string = normalize(string, '')
-
-  marked.default = {}
-
-  marked.use(
-    markedGovukMarkdown({
-      headingsStartWith: 'm'
-    })
-  )
-
-  marked.use(markedSmartypants())
-
-  return marked(string)
-}
 
 /**
  *


### PR DESCRIPTION
Ticket: https://trello.com/c/vNT3oAj8/3407-fix-memory-leak-issue-on-check

in xgov-uk package, the filter adds new middleware to the used package of marked. every time the filter is called. 

eventually, this middleware chain becomes too long and causes a stack overflow. 

I have opened a PR on the xgov uk repo: https://github.com/x-govuk/govuk-prototype-filters/pull/77

but for now, here is us implementing it ourselves to avoid this issue