### PR TITLE
only show 8 datasets on dashboard

### DIFF
--- a/src/controllers/OrganisationsController.js
+++ b/src/controllers/OrganisationsController.js
@@ -46,8 +46,18 @@ const organisationsController = {
     try {
       const lpa = req.params.lpa
 
+      const datasetsFilter = ['article-4-direction',
+        'article-4-direction-area',
+        'conservation-area',
+        'conservation-area-document',
+        'tree-preservation-order',
+        'tree-preservation-zone',
+        'tree',
+        'listed-building',
+        'listed-building-outline']
+
       // Make API request
-      const lpaOverview = await performanceDbApi.getLpaOverview(lpa)
+      const lpaOverview = await performanceDbApi.getLpaOverview(lpa, { datasetsFilter })
 
       // restructure datasets to usable format
       const datasets = Object.entries(lpaOverview.datasets).map(([key, value]) => {

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -63,10 +63,10 @@ export default {
    * @param {string} lpa - LPA ID
    * @returns {Promise<LpaOverview>} LPA overview
    */
-  getLpaOverview: async (lpa, { datasetsFilter }) => {
+  getLpaOverview: async (lpa, params = {}) => {
     let datasetClause = ''
-    if (datasetsFilter) {
-      const datasetString = datasetsFilter.map(dataset => `'${dataset}'`).join(',')
+    if (params.datasetsFilter) {
+      const datasetString = params.datasetsFilter.map(dataset => `'${dataset}'`).join(',')
       datasetClause = `AND rle.pipeline in (${datasetString})`
     }
 

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -64,9 +64,8 @@ export default {
    * @returns {Promise<LpaOverview>} LPA overview
    */
   getLpaOverview: async (lpa, { datasetsFilter }) => {
-    
     let datasetClause = ''
-    if(datasetsFilter){
+    if (datasetsFilter) {
       const datasetString = datasetsFilter.map(dataset => `'${dataset}'`).join(',')
       datasetClause = `AND rle.pipeline in (${datasetString})`
     }

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -63,7 +63,14 @@ export default {
    * @param {string} lpa - LPA ID
    * @returns {Promise<LpaOverview>} LPA overview
    */
-  getLpaOverview: async (lpa) => {
+  getLpaOverview: async (lpa, { datasetsFilter }) => {
+    
+    let datasetClause = ''
+    if(datasetsFilter){
+      const datasetString = datasetsFilter.map(dataset => `'${dataset}'`).join(',')
+      datasetClause = `AND rle.pipeline in (${datasetString})`
+    }
+
     const query = `
     SELECT
     p.organisation,
@@ -109,6 +116,7 @@ LEFT JOIN
     issue_type it ON i.issue_type = it.issue_type AND it.severity != 'info'
 WHERE
     p.organisation = '${lpa}'
+    ${datasetClause}
 GROUP BY
     p.organisation,
     p.dataset,

--- a/test/unit/performanceDbApi.test.js
+++ b/test/unit/performanceDbApi.test.js
@@ -52,6 +52,15 @@ describe('performanceDbApi', () => {
       })
     })
 
+    it('adds the filter if a dataset list is passed into the params', async () => {
+      vi.spyOn(datasette, 'runQuery').mockResolvedValue({ formattedData: [{ name: '' }] })
+
+      await performanceDbApi.getLpaOverview('lpa', { datasetsFilter: ['mock1', 'mock2', 'mock3'] })
+
+      expect(datasette.runQuery).toHaveBeenCalledTimes(1)
+      expect(datasette.runQuery).toHaveBeenCalledWith(expect.stringContaining('AND rle.pipeline in (\'mock1\',\'mock2\',\'mock3\')'))
+    })
+
     it('returns an error if the query fails', async () => {
       const lpa = 'some-lpa-id'
       const error = new Error('query failed')


### PR DESCRIPTION
Ticket: https://github.com/orgs/digital-land/projects/7/views/15?filterQuery=-status%3ABacklog%2CReady%2CDone%2CUnprioritised&pane=issue&itemId=74598465

this ticket updates the datasette query to ensure that only the 8 datasets the check tool is currently checking are shown in the dashboard