### PR TITLE
Ensure issue_count column is passed to templates

### DIFF
--- a/src/controllers/OrganisationsController.js
+++ b/src/controllers/OrganisationsController.js
@@ -71,6 +71,7 @@ const organisationsController = {
           datasets.push({
             slug: dataset,
             endpoint: null,
+            issue_count: 0,
             status: 'Not submitted'
           })
         }

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -137,7 +137,8 @@ ORDER BY
     const datasets = result.formattedData.reduce((accumulator, row) => {
       accumulator[row.dataset] = {
         endpoint: row.endpoint,
-        status: row.status
+        status: row.status,
+        issue_count: row.issue_count
       }
       return accumulator
     }, {})


### PR DESCRIPTION
Recent changes to the datasette query removed a column and now templates need to check issue_count instead of that column. But the view of the data did not include passed to the template did not include `issue_count`. This PR updates the code that creates the view to pass `issue_count`.
