### PR TITLE
Allow empty datasets in performanceDbApi.getLpaOverview()

### DIFF
--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -136,7 +136,7 @@ ORDER BY
       logger.info(`No records found for LPA=${lpa}`)
     }
 
-    let datasets = result.formattedData.reduce((accumulator, row) => {
+    const datasets = result.formattedData.reduce((accumulator, row) => {
       accumulator[row.dataset] = {
         endpoint: row.endpoint,
         status: row.status

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -49,7 +49,6 @@ fs.createReadStream('src/content/entityIssueMessages.csv')
 
 /**
  * @typedef {object} LpaOverview
- * @property {string} name
  * @property {{ [dataset: string]: Dataset }} datasets
  */
 
@@ -132,10 +131,12 @@ ORDER BY
     p.organisation,
     o.name;
 `
-
     const result = await datasette.runQuery(query)
+    if (result.formattedData.length === 0) {
+      logger.info(`No records found for LPA=${lpa}`)
+    }
 
-    const datasets = result.formattedData.reduce((accumulator, row) => {
+    let datasets = result.formattedData.reduce((accumulator, row) => {
       accumulator[row.dataset] = {
         endpoint: row.endpoint,
         status: row.status
@@ -143,13 +144,7 @@ ORDER BY
       return accumulator
     }, {})
 
-    if (result.formattedData.length === 0) {
-      throw new Error(`No records found for LPA=${lpa}`)
-    }
-
-    return {
-      datasets
-    }
+    return { datasets }
   },
 
   getResourceStatus: async (lpa, datasetId) => {

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -2,6 +2,7 @@
  * Performance DB API service
  */
 import datasette from './datasette.js'
+import logger from '../utils/logger.js'
 
 // ===========================================
 

--- a/src/services/performanceDbApi.js
+++ b/src/services/performanceDbApi.js
@@ -43,6 +43,7 @@ fs.createReadStream('src/content/entityIssueMessages.csv')
  * @typedef {object} Dataset
  * @property {'Not submitted' | 'Error' | 'Needs fixing' | 'Warning' | 'Live' } status
  * @property {string} endpoint
+ * @property {number} issue_count
  * @property {?string} error
  */
 


### PR DESCRIPTION
Empty datasets are a valid return value from `getLpaOverview()` query. This if following other changes that removed access of potentially `null` properties. 

Related [issue](https://github.com/digital-land/lpa-data-validator-frontend/issues/271#issue-2463309711)

